### PR TITLE
Add jansson library as replaceable of json-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,17 @@ LIBDIR=${PREFIX}/lib
 INCDIR=${PREFIX}/include
 
 CFLAGS+=-g -Wall -O2 -DDEBUG -fPIC
-LIBS=-lev -levbuffsock -lcurl -ljson-c
+LIBS=-lev -levbuffsock -lcurl
 AR=ar
 AR_FLAGS=rc
 RANLIB=ranlib
+
+ifeq (1, $(WITH_JANSSON))
+LIBS+=-ljansson
+CFLAGS+=-DWITH_JANSSON
+else
+LIBS+=-ljson-c
+endif
 
 all: libnsq test
 
@@ -16,7 +23,7 @@ libnsq: libnsq.a
 %.o: %.c
 	$(CC) -o $@ -c $< $(CFLAGS)
 
-libnsq.a: command.o reader.o nsqd_connection.o http.o message.o nsqlookupd.o
+libnsq.a: command.o reader.o nsqd_connection.o http.o message.o nsqlookupd.o json.o
 	$(AR) $(AR_FLAGS) $@ $^
 	$(RANLIB) $@
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,22 @@ TODO:
  * feature negotiation
  * better abstractions for responding to messages in your handlers
 
+### Build
+
+`libnsq` depends on `json-c` by default, but you can choose `jansson` for replacement.
+
+```sh
+WITH_JANSSON=1 make
+```
+
 ### Dependencies
 
  * [libev][2]
  * [libevbuffsock][3]
+ * [json-c][4] or [jansson][5]
 
 [1]: https://github.com/bitly/nsq
 [2]: http://software.schmorp.de/pkg/libev
 [3]: https://github.com/mreiferson/libevbuffsock
+[4]: https://github.com/json-c/json-c
+[5]: http://www.digip.org/jansson/

--- a/json.c
+++ b/json.c
@@ -1,0 +1,82 @@
+#include "json.h"
+
+nsq_json_tokener_t *nsq_json_tokener_new()
+{
+#ifdef WITH_JANSSON
+    return NULL;
+#else
+    return json_tokener_new();
+#endif
+}
+
+void nsq_json_tokener_free(nsq_json_tokener_t *jstok)
+{
+#ifndef WITH_JANSSON
+    json_tokener_free(jstok);
+#endif
+}
+
+int nsq_json_decref(nsq_json_t *jsobj)
+{
+#ifdef WITH_JANSSON
+    json_decref(jsobj);
+    return 0;
+#else
+    return json_object_put(jsobj);
+#endif
+}
+
+nsq_json_t *nsq_json_loadb(const char *buf, const nsq_json_size_t buflen, const size_t flags, nsq_json_tokener_t *jstok)
+{
+#ifdef WITH_JANSSON
+    return json_loadb(buf, (size_t)buflen, flags, NULL);
+#else
+    return json_tokener_parse_ex(jstok, buf, (int)buflen);
+#endif
+}
+
+nsq_json_size_t nsq_json_array_length(const nsq_json_t *array)
+{
+#ifdef WITH_JANSSON
+    return json_array_size(array);
+#else
+    return json_object_array_length(array);
+#endif
+}
+
+nsq_json_t *nsq_json_array_get(const nsq_json_t *array, const nsq_json_size_t idx)
+{
+#ifdef WITH_JANSSON
+    return json_array_get(array, idx);
+#else
+    return json_object_array_get_idx(array, idx);
+#endif
+}
+
+int nsq_json_object_get(const nsq_json_t *jsobj, const char *key, nsq_json_t **value)
+{
+#ifdef WITH_JANSSON
+    *value = json_object_get(jsobj, key);
+    return *value != NULL;
+#else
+    return json_object_object_get_ex(jsobj, key, value);
+#endif
+}
+
+const char *nsq_json_string_value(nsq_json_t *jsobj)
+{
+#ifdef WITH_JANSSON
+    return json_string_value(jsobj);
+#else
+    return json_object_get_string(jsobj);
+#endif
+}
+
+nsq_json_int_t nsq_json_int_value(const nsq_json_t *jsobj)
+{
+#ifdef WITH_JANSSON
+    return json_integer_value(jsobj);
+#else
+    return json_object_get_int(jsobj);
+#endif
+}

--- a/json.h
+++ b/json.h
@@ -1,0 +1,34 @@
+#ifndef __json_h
+#define __json_h
+
+#ifdef WITH_JANSSON
+
+#include <jansson.h>
+
+typedef json_t      nsq_json_t;
+typedef size_t      nsq_json_size_t;
+typedef json_int_t  nsq_json_int_t;
+typedef void        nsq_json_tokener_t;
+
+#else
+
+#include <json-c/json.h>
+
+typedef struct json_object     nsq_json_t;
+typedef int                    nsq_json_size_t;
+typedef int32_t                nsq_json_int_t;
+typedef struct json_tokener    nsq_json_tokener_t;
+
+#endif
+
+nsq_json_tokener_t *nsq_json_tokener_new();
+void nsq_json_tokener_free(nsq_json_tokener_t *jstok);
+int nsq_json_decref(nsq_json_t *jsobj);
+nsq_json_t *nsq_json_loadb(const char *buf, const nsq_json_size_t buflen, const size_t flags, nsq_json_tokener_t *jstok);
+nsq_json_size_t nsq_json_array_length(const nsq_json_t *array);
+nsq_json_t *nsq_json_array_get(const nsq_json_t *array, const nsq_json_size_t idx);
+int nsq_json_object_get(const nsq_json_t *jsobj, const char *key, nsq_json_t **value);
+const char *nsq_json_string_value(nsq_json_t *jsojb);
+nsq_json_int_t nsq_json_int_value(const nsq_json_t *jsobj);
+
+#endif /* ifndef __json_h */

--- a/nsqlookupd.c
+++ b/nsqlookupd.c
@@ -1,4 +1,4 @@
-#include <json-c/json.h>
+#include "json.h"
 #include "nsq.h"
 #include "http.h"
 
@@ -11,8 +11,8 @@
 void nsq_lookupd_request_cb(struct HttpRequest *req, struct HttpResponse *resp, void *arg)
 {
     struct NSQReader *rdr = (struct NSQReader *)arg;
-    struct json_object *jsobj, *data, *producers, *producer, *broadcast_address_obj, *tcp_port_obj;
-    struct json_tokener *jstok;
+    nsq_json_t *jsobj, *data, *producers, *producer, *broadcast_address_obj, *tcp_port_obj;
+    nsq_json_tokener_t *jstok;
     struct NSQDConnection *conn;
     const char *broadcast_address;
     int i, found, tcp_port;
@@ -26,37 +26,37 @@ void nsq_lookupd_request_cb(struct HttpRequest *req, struct HttpResponse *resp, 
         return;
     }
 
-    jstok = json_tokener_new();
-    jsobj = json_tokener_parse_ex(jstok, resp->data->data, (int)BUFFER_HAS_DATA(resp->data));
+    jstok = nsq_json_tokener_new();
+    jsobj = nsq_json_loadb(resp->data->data, (nsq_json_size_t)BUFFER_HAS_DATA(resp->data), 0, jstok);
     if (!jsobj) {
         _DEBUG("%s: error parsing JSON\n", __FUNCTION__);
-        json_tokener_free(jstok);
+        nsq_json_tokener_free(jstok);
         return;
     }
 
-    json_object_object_get_ex(jsobj, "data", &data);
+    nsq_json_object_get(jsobj, "data", &data);
     if (!data) {
         _DEBUG("%s: error getting 'data' key\n", __FUNCTION__);
-        json_object_put(jsobj);
-        json_tokener_free(jstok);
+        nsq_json_decref(jsobj);
+        nsq_json_tokener_free(jstok);
         return;
     }
-    json_object_object_get_ex(data, "producers", &producers);
+    nsq_json_object_get(data, "producers", &producers);
     if (!producers) {
         _DEBUG("%s: error getting 'producers' key\n", __FUNCTION__);
-        json_object_put(jsobj);
-        json_tokener_free(jstok);
+        nsq_json_decref(jsobj);
+        nsq_json_tokener_free(jstok);
         return;
     }
 
-    _DEBUG("%s: num producers %d\n", __FUNCTION__, json_object_array_length(producers));
-    for (i = 0; i < json_object_array_length(producers); i++) {
-        producer = json_object_array_get_idx(producers, i);
-        json_object_object_get_ex(producer, "broadcast_address", &broadcast_address_obj);
-        json_object_object_get_ex(producer, "tcp_port", &tcp_port_obj);
+    _DEBUG("%s: num producers %ld\n", __FUNCTION__, (long)nsq_json_array_length(producers));
+    for (i = 0; i < nsq_json_array_length(producers); i++) {
+        producer = nsq_json_array_get(producers, i);
+        nsq_json_object_get(producer, "broadcast_address", &broadcast_address_obj);
+        nsq_json_object_get(producer, "tcp_port", &tcp_port_obj);
 
-        broadcast_address = json_object_get_string(broadcast_address_obj);
-        tcp_port = json_object_get_int(tcp_port_obj);
+        broadcast_address = nsq_json_string_value(broadcast_address_obj);
+        tcp_port = nsq_json_int_value(tcp_port_obj);
 
         _DEBUG("%s: broadcast_address %s, port %d\n", __FUNCTION__, broadcast_address, tcp_port);
 
@@ -74,8 +74,8 @@ void nsq_lookupd_request_cb(struct HttpRequest *req, struct HttpResponse *resp, 
         }
     }
 
-    json_object_put(jsobj);
-    json_tokener_free(jstok);
+    nsq_json_decref(jsobj);
+    nsq_json_tokener_free(jstok);
 
     free_http_response(resp);
     free_http_request(req);


### PR DESCRIPTION
Since `jansson` and `json-c` conflict with each other in namespace, they can't be used as dependency together in a project. That means `libnsq` can't be used with any other library which depends on `jansson` (e.g. `avro-c`).

*Note*: This PR is in conflict with #8 .