### PR TITLE
astyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ else
 LIBS+=-ljson-c
 endif
 
+LIBNSQ_HEADERS = \
+nsq.h \
+http.h
+
 LIBNSQ_SOURCES = \
 command.c \
 message.c \
@@ -37,6 +41,18 @@ libnsq: libnsq.a
 libnsq.a: $(patsubst %.c, %.o, ${LIBNSQ_SOURCES})
 	$(AR) $(AR_FLAGS) $@ $^
 	$(RANLIB) $@
+
+fmt: ${LIBNSQ_SOURCES} ${LIBNSQ_HEADERS}
+	astyle --style=1tbs \
+		--lineend=linux \
+		--convert-tabs \
+		--preserve-date \
+		--pad-header \
+		--indent-switches \
+		--align-pointer=name \
+		--align-reference=name \
+		--pad-oper \
+		-n $^
 
 test: test-nsqd test-lookupd test-evbuffsock
 

--- a/buffer.c
+++ b/buffer.c
@@ -11,14 +11,14 @@
 struct Buffer *new_buffer(size_t length, size_t capacity)
 {
     struct Buffer *buf;
-    
+
     buf = malloc(sizeof(struct Buffer));
     buf->orig = malloc(length);
     buf->data = buf->orig;
     buf->offset = 0;
     buf->length = length;
     buf->capacity = capacity;
-    
+
     return buf;
 }
 
@@ -41,9 +41,9 @@ int buffer_expand(struct Buffer *buf, size_t need)
     size_t pos = buf->data - buf->orig;
     size_t expand = 0;
     size_t new_size = 0;
-    
+
     _DEBUG("%s: need %lu, pos %lu\n", __FUNCTION__, need, pos);
-    
+
     if (need <= pos) {
         _DEBUG("%s: re-aligning\n", __FUNCTION__);
         // re-align
@@ -51,23 +51,23 @@ int buffer_expand(struct Buffer *buf, size_t need)
         buf->data = buf->orig;
         return 1;
     }
-    
+
     expand = buf->length;
     while (expand < need) {
         expand = expand * 2;
     }
-    
+
     _DEBUG("%s: expanding by %lu\n", __FUNCTION__, expand);
-    
+
     new_size = buf->length + expand;
     if (buf->capacity > 0 && new_size > buf->capacity) {
         return 0;
     }
-    
+
     buf->orig = realloc(buf->orig, new_size);
     buf->data = buf->orig + pos;
     buf->length = new_size;
-    
+
     return 1;
 }
 
@@ -75,18 +75,18 @@ int buffer_add(struct Buffer *buf, const void *source, size_t length)
 {
     size_t used = buf->data - buf->orig + buf->offset;
     int32_t need = used + length - buf->length;
-    
+
     _DEBUG("%s: adding %lu - used %lu, need %d\n", __FUNCTION__, length, used, need);
-    
+
     if (need > 0) {
         if (!buffer_expand(buf, need)) {
             return 0;
         }
     }
-    
+
     memcpy(buf->data + buf->offset, source, length);
     buf->offset += length;
-    
+
     return 1;
 }
 
@@ -104,21 +104,21 @@ int buffer_read_fd(struct Buffer *buf, int fd)
 {
     int n;
     int need;
-    
+
     if (ioctl(fd, FIONREAD, &n) == -1 || n > 4096) {
         n = 4096;
     }
-    
+
     need = n - BUFFER_AVAILABLE(buf);
     if (need > 0 && !buffer_expand(buf, need)) {
         return -1;
     }
-    
+
     n = recv(fd, buf->data + buf->offset, n, 0);
     if (n > 0) {
         buf->offset += n;
     }
-    
+
     return n;
 }
 

--- a/buffered_socket.c
+++ b/buffered_socket.c
@@ -125,7 +125,7 @@ static void buffered_socket_connect_cb(int revents, void *arg)
 
     if (revents & EV_TIMEOUT) {
         _DEBUG("%s: connection timeout for \"%s:%d\" on %d\n",
-            __FUNCTION__, buffsock->address, buffsock->port, buffsock->fd);
+               __FUNCTION__, buffsock->address, buffsock->port, buffsock->fd);
 
         buffered_socket_close(buffsock);
         return;
@@ -240,7 +240,7 @@ static void buffered_socket_read_bytes_cb(EV_P_ struct ev_timer *w, int revents)
 }
 
 void buffered_socket_read_bytes(struct BufferedSocket *buffsock, size_t n,
-    void (*data_callback)(struct BufferedSocket *buffsock, void *arg), void *arg)
+                                void (*data_callback)(struct BufferedSocket *buffsock, void *arg), void *arg)
 {
     buffsock->read_bytes_callback = data_callback;
     buffsock->read_bytes_arg = arg;

--- a/command.c
+++ b/command.c
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 
 
-static void nsq_buffer_add(nsqBuf *buf, const char *name,
-                           const nsqCmdParams params[], size_t psize,
+static void nsq_buffer_add(struct Buffer *buf, const char *name,
+                           const struct NSQCmdParams params[], size_t psize,
                            const char *body, const size_t body_length)
 {
     char b[64];
@@ -39,72 +39,72 @@ static void nsq_buffer_add(nsqBuf *buf, const char *name,
     }
 }
 
-void nsq_subscribe(nsqBuf *buf, const char *topic, const char *channel)
+void nsq_subscribe(struct Buffer *buf, const char *topic, const char *channel)
 {
     const char *name = "SUB";
-    const nsqCmdParams params[2] = {
+    const struct NSQCmdParams params[2] = {
         {(void *)topic, NSQ_PARAM_TYPE_CHAR},
         {(void *)channel, NSQ_PARAM_TYPE_CHAR},
     };
     nsq_buffer_add(buf, name, params, 2, NULL, 0);
 }
 
-void nsq_ready(nsqBuf *buf, int count)
+void nsq_ready(struct Buffer *buf, int count)
 {
     const char *name = "RDY";
-    const nsqCmdParams params[1] = {
+    const struct NSQCmdParams params[1] = {
         {&count, NSQ_PARAM_TYPE_INT},
     };
     nsq_buffer_add(buf, name, params, 1, NULL, 0);
 }
 
-void nsq_finish(nsqBuf *buf, const char *id)
+void nsq_finish(struct Buffer *buf, const char *id)
 {
     const char *name = "FIN";
-    const nsqCmdParams params[1] = {
+    const struct NSQCmdParams params[1] = {
         {(void *)id, NSQ_PARAM_TYPE_CHAR},
     };
     nsq_buffer_add(buf, name, params, 1, NULL, 0);
 }
 
-void nsq_requeue(nsqBuf *buf, const char *id, int timeout_ms)
+void nsq_requeue(struct Buffer *buf, const char *id, int timeout_ms)
 {
     const char *name = "REQ";
-    const nsqCmdParams params[2] = {
+    const struct NSQCmdParams params[2] = {
         {(void *)id, NSQ_PARAM_TYPE_CHAR},
         {&timeout_ms, NSQ_PARAM_TYPE_INT},
     };
     nsq_buffer_add(buf, name, params, 2, NULL, 0);
 }
 
-void nsq_nop(nsqBuf *buf)
+void nsq_nop(struct Buffer *buf)
 {
     nsq_buffer_add(buf, "NOP", NULL, 0, NULL, 0);
 }
 
-void nsq_publish(nsqBuf *buf, const char *topic, const char *body)
+void nsq_publish(struct Buffer *buf, const char *topic, const char *body)
 {
     const char *name = "PUB";
-    const nsqCmdParams params[1] = {
+    const struct NSQCmdParams params[1] = {
         {(void *)topic, NSQ_PARAM_TYPE_CHAR},
     };
     nsq_buffer_add(buf, name, params, 1, body, strlen(body));
 }
 
-void nsq_defer_publish(nsqBuf *buf, const char *topic, const char *body, int defer_time_sec)
+void nsq_defer_publish(struct Buffer *buf, const char *topic, const char *body, int defer_time_sec)
 {
     const char *name = "DPUB";
-    const nsqCmdParams params[2] = {
+    const struct NSQCmdParams params[2] = {
         {(void *)topic, NSQ_PARAM_TYPE_CHAR},
         {&defer_time_sec, NSQ_PARAM_TYPE_INT},
     };
     nsq_buffer_add(buf, name, params, 2, body, strlen(body));
 }
 
-void nsq_multi_publish(nsqBuf *buf, const char *topic, const char **body, const size_t body_size)
+void nsq_multi_publish(struct Buffer *buf, const char *topic, const char **body, const size_t body_size)
 {
     const char *name = "MPUB";
-    const nsqCmdParams params[1] = {
+    const struct NSQCmdParams params[1] = {
         {(void *)topic, NSQ_PARAM_TYPE_CHAR},
     };
 
@@ -136,29 +136,29 @@ void nsq_multi_publish(nsqBuf *buf, const char *topic, const char **body, const 
     nsq_buffer_add(buf, name, params, 1, b, s);
 }
 
-void nsq_touch(nsqBuf *buf, const char *id)
+void nsq_touch(struct Buffer *buf, const char *id)
 {
     const char *name = "TOUCH";
-    const nsqCmdParams params[1] = {
+    const struct NSQCmdParams params[1] = {
         {(void *)id, NSQ_PARAM_TYPE_CHAR},
     };
     nsq_buffer_add(buf, name, params, 1, NULL, 0);
 }
 
-void nsq_cleanly_close_connection(nsqBuf *buf)
+void nsq_cleanly_close_connection(struct Buffer *buf)
 {
     const char *name = "CLS";
     nsq_buffer_add(buf, name, NULL, 0, NULL, 0);
 }
 
-void nsq_auth(nsqBuf *buf, const char *secret)
+void nsq_auth(struct Buffer *buf, const char *secret)
 {
     const char *name = "AUTH";
     nsq_buffer_add(buf, name, NULL, 0, secret, strlen(secret));
 }
 
 //TODO: should handle object to json string
-void nsq_identify(nsqBuf *buf, const char *json_body)
+void nsq_identify(struct Buffer *buf, const char *json_body)
 {
     const char *name = "IDENTIFY";
     nsq_buffer_add(buf, name, NULL, 1, json_body, strlen(json_body));

--- a/command.c
+++ b/command.c
@@ -109,8 +109,8 @@ void nsq_multi_publish(nsqBuf *buf, const char *topic, const char **body, const 
     };
 
     size_t s = 4;
-    for (size_t i = 0; i<body_size; i++) {
-        s += strlen(body[i])+4;
+    for (size_t i = 0; i < body_size; i++) {
+        s += strlen(body[i]) + 4;
     }
     char *b = malloc(s * sizeof(char));
     assert(NULL != b);
@@ -118,18 +118,18 @@ void nsq_multi_publish(nsqBuf *buf, const char *topic, const char **body, const 
     size_t n = 0;
     uint32_t v = 0;
     v = htonl((uint32_t)body_size);
-    memcpy(b+n, &v, 4);
+    memcpy(b + n, &v, 4);
     n += 4;
 
     size_t l = 0;
     for (size_t i = 0; i < body_size; i++) {
         l = strlen(body[i]);
         v = htonl((uint32_t)l);
-        memcpy(b+n, &v, 4);
+        memcpy(b + n, &v, 4);
         n += 4;
 
         l = strlen(body[i]);
-        memcpy(b+n, body[i], l);
+        memcpy(b + n, body[i], l);
         n += l;
     }
 

--- a/evbuffsock.h
+++ b/evbuffsock.h
@@ -81,7 +81,7 @@ int buffered_socket_connect(struct BufferedSocket *buffsock);
 void buffered_socket_close(struct BufferedSocket *socket);
 size_t buffered_socket_write(struct BufferedSocket *buffsock, void *data, size_t len);
 size_t buffered_socket_write_buffer(struct BufferedSocket *buffsock, struct Buffer *buf);
-void buffered_socket_read_bytes(struct BufferedSocket *buffsock, size_t n, 
-    void (*data_callback)(struct BufferedSocket *buffsock, void *arg), void *arg);
+void buffered_socket_read_bytes(struct BufferedSocket *buffsock, size_t n,
+                                void (*data_callback)(struct BufferedSocket *buffsock, void *arg), void *arg);
 
 #endif

--- a/http.c
+++ b/http.c
@@ -148,7 +148,7 @@ void free_http_client(httpClient *httpc)
 }
 
 httpRequest *new_http_request(const char *url,
-    void (*callback)(httpRequest *req, httpResponse *resp, void *arg), void *cb_arg)
+                              void (*callback)(httpRequest *req, httpResponse *resp, void *arg), void *cb_arg)
 {
     httpRequest *req;
 

--- a/http.h
+++ b/http.h
@@ -6,19 +6,19 @@
 
 struct Buffer; // from evbuffsock.h
 
-typedef struct HttpClient {
+struct HttpClient {
     CURLM *multi;
     struct ev_loop *loop;
     struct ev_timer timer_event;
     int still_running;
-} httpClient;
+};
 
-typedef struct HttpResponse {
+struct HttpResponse {
     int status_code;
     struct Buffer *data;
-} httpResponse;
+};
 
-typedef struct HttpRequest {
+struct HttpRequest {
     CURL *easy;
     char *url;
     struct HttpClient *httpc;
@@ -26,9 +26,9 @@ typedef struct HttpRequest {
     struct Buffer *data;
     void (*callback)(struct HttpRequest *req, struct HttpResponse *resp, void *arg);
     void *cb_arg;
-} httpRequest;
+};
 
-typedef struct HttpSocket {
+struct HttpSocket {
     curl_socket_t sockfd;
     CURL *easy;
     int action;
@@ -36,7 +36,7 @@ typedef struct HttpSocket {
     struct ev_io ev;
     int evset;
     struct HttpClient *httpc;
-} httpSocket;
+};
 
 struct HttpClient *new_http_client(struct ev_loop *loop);
 void free_http_client(struct HttpClient *httpc);

--- a/http.h
+++ b/http.h
@@ -41,7 +41,7 @@ typedef struct HttpSocket {
 struct HttpClient *new_http_client(struct ev_loop *loop);
 void free_http_client(struct HttpClient *httpc);
 struct HttpRequest *new_http_request(const char *url,
-    void (*callback)(struct HttpRequest *req, struct HttpResponse *resp, void *arg), void *cb_arg);
+                                     void (*callback)(struct HttpRequest *req, struct HttpResponse *resp, void *arg), void *cb_arg);
 void free_http_request(struct HttpRequest *req);
 struct HttpResponse *new_http_response(int status_code, void *data);
 void free_http_response(struct HttpResponse *resp);

--- a/message.c
+++ b/message.c
@@ -11,12 +11,12 @@ uint64_t ntoh64(const uint8_t *data)
            (uint64_t)(data[1]) << 48 | (uint64_t)(data[0]) << 56;
 }
 
-nsqMsg *nsq_decode_message(const char *data, size_t data_length)
+struct NSQMessage *nsq_decode_message(const char *data, size_t data_length)
 {
-    nsqMsg *msg;
+    struct NSQMessage *msg;
     size_t body_length;
 
-    msg = (nsqMsg *)malloc(sizeof(nsqMsg));
+    msg = (struct NSQMessage *)malloc(sizeof(struct NSQMessage));
     msg->timestamp = (int64_t)ntoh64((uint8_t *)data);
     msg->attempts = ntohs(*(uint16_t *)(data + 8));
     memcpy(&msg->id, data + 10, 16);
@@ -28,7 +28,7 @@ nsqMsg *nsq_decode_message(const char *data, size_t data_length)
     return msg;
 }
 
-void free_nsq_message(nsqMsg *msg)
+void free_nsq_message(struct NSQMessage *msg)
 {
     if (msg) {
         free(msg->body);

--- a/message.c
+++ b/message.c
@@ -3,11 +3,12 @@
 
 #include "nsq.h"
 
-uint64_t ntoh64(const uint8_t *data) {
-    return (uint64_t)(data[7]) | (uint64_t)(data[6])<<8 |
-        (uint64_t)(data[5])<<16 | (uint64_t)(data[4])<<24 |
-        (uint64_t)(data[3])<<32 | (uint64_t)(data[2])<<40 |
-        (uint64_t)(data[1])<<48 | (uint64_t)(data[0])<<56;
+uint64_t ntoh64(const uint8_t *data)
+{
+    return (uint64_t)(data[7]) | (uint64_t)(data[6]) << 8 |
+           (uint64_t)(data[5]) << 16 | (uint64_t)(data[4]) << 24 |
+           (uint64_t)(data[3]) << 32 | (uint64_t)(data[2]) << 40 |
+           (uint64_t)(data[1]) << 48 | (uint64_t)(data[0]) << 56;
 }
 
 nsqMsg *nsq_decode_message(const char *data, size_t data_length)
@@ -17,11 +18,11 @@ nsqMsg *nsq_decode_message(const char *data, size_t data_length)
 
     msg = (nsqMsg *)malloc(sizeof(nsqMsg));
     msg->timestamp = (int64_t)ntoh64((uint8_t *)data);
-    msg->attempts = ntohs(*(uint16_t *)(data+8));
-    memcpy(&msg->id, data+10, 16);
+    msg->attempts = ntohs(*(uint16_t *)(data + 8));
+    memcpy(&msg->id, data + 10, 16);
     body_length = data_length - 26;
     msg->body = (char *)malloc(body_length);
-    memcpy(msg->body, data+26, body_length);
+    memcpy(msg->body, data + 26, body_length);
     msg->body_length = body_length;
 
     return msg;

--- a/nsq.h
+++ b/nsq.h
@@ -83,10 +83,10 @@ typedef struct NSQReader {
 } nsqRdr;
 
 nsqRdr *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *channel, void *ctx,
-    nsqRdrCfg *cfg,
-    void (*connect_callback)(nsqRdr *rdr, nsqdConn *conn),
-    void (*close_callback)(nsqRdr *rdr, nsqdConn *conn),
-    void (*msg_callback)(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx));
+                       nsqRdrCfg *cfg,
+                       void (*connect_callback)(nsqRdr *rdr, nsqdConn *conn),
+                       void (*close_callback)(nsqRdr *rdr, nsqdConn *conn),
+                       void (*msg_callback)(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx));
 void free_nsq_reader(nsqRdr *rdr);
 int nsq_reader_connect_to_nsqd(nsqRdr *rdr, const char *address, int port);
 int nsq_reader_connect_to_nsqlookupd(nsqRdr *rdr);
@@ -95,16 +95,16 @@ void nsq_reader_set_loop(nsqRdr *rdr, struct ev_loop *loop);
 void nsq_run(struct ev_loop *loop);
 
 nsqdConn *new_nsqd_connection(struct ev_loop *loop, const char *address, int port,
-    void (*connect_callback)(nsqdConn *conn, void *arg),
-    void (*close_callback)(nsqdConn *conn, void *arg),
-    void (*msg_callback)(nsqdConn *conn, nsqMsg *msg, void *arg),
-    void *arg);
+                              void (*connect_callback)(nsqdConn *conn, void *arg),
+                              void (*close_callback)(nsqdConn *conn, void *arg),
+                              void (*msg_callback)(nsqdConn *conn, nsqMsg *msg, void *arg),
+                              void *arg);
 void free_nsqd_connection(nsqdConn *conn);
 int nsqd_connection_connect(nsqdConn *conn);
 void nsqd_connection_disconnect(nsqdConn *conn);
 
 void nsqd_connection_init_timer(nsqdConn *conn,
-        void (*reconnect_callback)(EV_P_ ev_timer *w, int revents));
+                                void (*reconnect_callback)(EV_P_ ev_timer *w, int revents));
 void nsqd_connection_stop_timer(nsqdConn *conn);
 
 void nsq_subscribe(nsqBuf *buf, const char *topic, const char *channel);

--- a/nsq.h
+++ b/nsq.h
@@ -16,29 +16,27 @@ struct Buffer; // from evbuffsock.h
 
 typedef enum {NSQ_FRAME_TYPE_RESPONSE, NSQ_FRAME_TYPE_ERROR, NSQ_FRAME_TYPE_MESSAGE} frame_type;
 typedef enum {NSQ_PARAM_TYPE_INT, NSQ_PARAM_TYPE_CHAR} nsq_cmd_param_type;
-typedef struct Buffer nsqBuf;
-typedef struct BufferedSocket nsqBufdSock;
 
-typedef struct NSQCmdParams {
+struct NSQCmdParams {
     void *v;
     int t;
-} nsqCmdParams;
+};
 
-typedef struct NSQMessage {
+struct NSQMessage {
     int64_t timestamp;
     uint16_t attempts;
-    char id[16+1];
+    char id[16 + 1];
     size_t body_length;
     char *body;
-} nsqMsg;
+};
 
-typedef struct NSQLookupdEndpoint {
+struct NSQLookupdEndpoint {
     char *address;
     int port;
     struct NSQLookupdEndpoint *next;
-} nsqLE;
+};
 
-typedef struct NSQDConnection {
+struct NSQDConnection {
     char *address;
     int port;
     struct BufferedSocket *bs;
@@ -50,12 +48,12 @@ typedef struct NSQDConnection {
     ev_timer *reconnect_timer;
     void (*connect_callback)(struct NSQDConnection *conn, void *arg);
     void (*close_callback)(struct NSQDConnection *conn, void *arg);
-    void (*msg_callback)(struct NSQDConnection *conn, nsqMsg *msg, void *arg);
+    void (*msg_callback)(struct NSQDConnection *conn, struct NSQMessage *msg, void *arg);
     void *arg;
     struct NSQDConnection *next;
-} nsqdConn;
+};
 
-typedef struct NSQReaderCfg {
+struct NSQReaderCfg {
     ev_tstamp lookupd_interval;
     size_t command_buf_len;
     size_t command_buf_capacity;
@@ -63,67 +61,67 @@ typedef struct NSQReaderCfg {
     size_t read_buf_capacity;
     size_t write_buf_len;
     size_t write_buf_capacity;
-} nsqRdrCfg;
+};
 
-typedef struct NSQReader {
+struct NSQReader {
     char *topic;
     char *channel;
     void *ctx; //context for call back
     int max_in_flight;
-    nsqdConn *conns;
+    struct NSQDConnection *conns;
     struct NSQDConnInfo *infos;
-    nsqLE *lookupd;
+    struct NSQLookupdEndpoint *lookupd;
     struct ev_timer lookupd_poll_timer;
     struct ev_loop *loop;
-    nsqRdrCfg *cfg;
+    struct NSQReaderCfg *cfg;
     void *httpc;
-    void (*connect_callback)(struct NSQReader *rdr, nsqdConn *conn);
-    void (*close_callback)(struct NSQReader *rdr, nsqdConn *conn);
-    void (*msg_callback)(struct NSQReader *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx);
-} nsqRdr;
+    void (*connect_callback)(struct NSQReader *rdr, struct NSQDConnection *conn);
+    void (*close_callback)(struct NSQReader *rdr, struct NSQDConnection *conn);
+    void (*msg_callback)(struct NSQReader *rdr, struct NSQDConnection *conn, struct NSQMessage *msg, void *ctx);
+};
 
-nsqRdr *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *channel, void *ctx,
-                       nsqRdrCfg *cfg,
-                       void (*connect_callback)(nsqRdr *rdr, nsqdConn *conn),
-                       void (*close_callback)(nsqRdr *rdr, nsqdConn *conn),
-                       void (*msg_callback)(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx));
-void free_nsq_reader(nsqRdr *rdr);
-int nsq_reader_connect_to_nsqd(nsqRdr *rdr, const char *address, int port);
-int nsq_reader_connect_to_nsqlookupd(nsqRdr *rdr);
-int nsq_reader_add_nsqlookupd_endpoint(nsqRdr *rdr, const char *address, int port);
-void nsq_reader_set_loop(nsqRdr *rdr, struct ev_loop *loop);
+struct NSQReader *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *channel, void *ctx,
+                                 struct NSQReaderCfg *cfg,
+                                 void (*connect_callback)(struct NSQReader *rdr, struct NSQDConnection *conn),
+                                 void (*close_callback)(struct NSQReader *rdr, struct NSQDConnection *conn),
+                                 void (*msg_callback)(struct NSQReader *rdr, struct NSQDConnection *conn, struct NSQMessage *msg, void *ctx));
+void free_nsq_reader(struct NSQReader *rdr);
+int nsq_reader_connect_to_nsqd(struct NSQReader *rdr, const char *address, int port);
+int nsq_reader_connect_to_nsqlookupd(struct NSQReader *rdr);
+int nsq_reader_add_nsqlookupd_endpoint(struct NSQReader *rdr, const char *address, int port);
+void nsq_reader_set_loop(struct NSQReader *rdr, struct ev_loop *loop);
 void nsq_run(struct ev_loop *loop);
 
-nsqdConn *new_nsqd_connection(struct ev_loop *loop, const char *address, int port,
-                              void (*connect_callback)(nsqdConn *conn, void *arg),
-                              void (*close_callback)(nsqdConn *conn, void *arg),
-                              void (*msg_callback)(nsqdConn *conn, nsqMsg *msg, void *arg),
-                              void *arg);
-void free_nsqd_connection(nsqdConn *conn);
-int nsqd_connection_connect(nsqdConn *conn);
-void nsqd_connection_disconnect(nsqdConn *conn);
+struct NSQDConnection *new_nsqd_connection(struct ev_loop *loop, const char *address, int port,
+        void (*connect_callback)(struct NSQDConnection *conn, void *arg),
+        void (*close_callback)(struct NSQDConnection *conn, void *arg),
+        void (*msg_callback)(struct NSQDConnection *conn, struct NSQMessage *msg, void *arg),
+        void *arg);
+void free_nsqd_connection(struct NSQDConnection *conn);
+int nsqd_connection_connect(struct NSQDConnection *conn);
+void nsqd_connection_disconnect(struct NSQDConnection *conn);
 
-void nsqd_connection_init_timer(nsqdConn *conn,
+void nsqd_connection_init_timer(struct NSQDConnection *conn,
                                 void (*reconnect_callback)(EV_P_ ev_timer *w, int revents));
-void nsqd_connection_stop_timer(nsqdConn *conn);
+void nsqd_connection_stop_timer(struct NSQDConnection *conn);
 
-void nsq_subscribe(nsqBuf *buf, const char *topic, const char *channel);
-void nsq_ready(nsqBuf *buf, int count);
-void nsq_finish(nsqBuf *buf, const char *id);
-void nsq_requeue(nsqBuf *buf, const char *id, int timeout_ms);
-void nsq_nop(nsqBuf *buf);
-void nsq_publish(nsqBuf *buf, const char *topic, const char *body);
-void nsq_multi_publish(nsqBuf *buf, const char *topic, const char **body, const size_t body_size);
-void nsq_defer_publish(nsqBuf *buf, const char *topic, const char *body, int defer_time_sec);
-void nsq_touch(nsqBuf *buf, const char *id);
-void nsq_cleanly_close_connection(nsqBuf *buf);
-void nsq_auth(nsqBuf *buf, const char *secret);
-void nsq_identify(nsqBuf *buf, const char *json_body);
+void nsq_subscribe(struct Buffer *buf, const char *topic, const char *channel);
+void nsq_ready(struct Buffer *buf, int count);
+void nsq_finish(struct Buffer *buf, const char *id);
+void nsq_requeue(struct Buffer *buf, const char *id, int timeout_ms);
+void nsq_nop(struct Buffer *buf);
+void nsq_publish(struct Buffer *buf, const char *topic, const char *body);
+void nsq_multi_publish(struct Buffer *buf, const char *topic, const char **body, const size_t body_size);
+void nsq_defer_publish(struct Buffer *buf, const char *topic, const char *body, int defer_time_sec);
+void nsq_touch(struct Buffer *buf, const char *id);
+void nsq_cleanly_close_connection(struct Buffer *buf);
+void nsq_auth(struct Buffer *buf, const char *secret);
+void nsq_identify(struct Buffer *buf, const char *json_body);
 
-nsqMsg *nsq_decode_message(const char *data, size_t data_length);
-void free_nsq_message(nsqMsg *msg);
+struct NSQMessage *nsq_decode_message(const char *data, size_t data_length);
+void free_nsq_message(struct NSQMessage *msg);
 
-nsqLE *new_nsqlookupd_endpoint(const char *address, int port);
-void free_nsqlookupd_endpoint(nsqLE *nsqlookupd_endpoint);
+struct NSQLookupdEndpoint *new_nsqlookupd_endpoint(const char *address, int port);
+void free_nsqlookupd_endpoint(struct NSQLookupdEndpoint *nsqlookupd_endpoint);
 
 #endif

--- a/nsqd_connection.c
+++ b/nsqd_connection.c
@@ -52,7 +52,7 @@ static void nsqd_connection_read_data(nsqBufdSock *buffsock, void *arg)
     conn->current_msg_size -= 4;
 
     _DEBUG("%s: frame type %d, data: %.*s\n", __FUNCTION__, conn->current_frame_type,
-        conn->current_msg_size, buffsock->read_buf->data);
+           conn->current_msg_size, buffsock->read_buf->data);
 
     conn->current_data = buffsock->read_buf->data;
     switch (conn->current_frame_type) {
@@ -95,10 +95,10 @@ static void nsqd_connection_error_cb(nsqBufdSock *buffsock, void *arg)
 }
 
 nsqdConn *new_nsqd_connection(struct ev_loop *loop, const char *address, int port,
-    void (*connect_callback)(nsqdConn *conn, void *arg),
-    void (*close_callback)(nsqdConn *conn, void *arg),
-    void (*msg_callback)(nsqdConn *conn, nsqMsg *msg, void *arg),
-    void *arg)
+                              void (*connect_callback)(nsqdConn *conn, void *arg),
+                              void (*close_callback)(nsqdConn *conn, void *arg),
+                              void (*msg_callback)(nsqdConn *conn, nsqMsg *msg, void *arg),
+                              void *arg)
 {
     nsqdConn *conn;
     nsqRdr *rdr = (nsqRdr *)arg;
@@ -116,11 +116,11 @@ nsqdConn *new_nsqd_connection(struct ev_loop *loop, const char *address, int por
     conn->reconnect_timer = NULL;
 
     conn->bs = new_buffered_socket(loop, address, port,
-        rdr->cfg->read_buf_len, rdr->cfg->read_buf_capacity,
-        rdr->cfg->write_buf_len, rdr->cfg->write_buf_capacity,
-        nsqd_connection_connect_cb, nsqd_connection_close_cb,
-        NULL, NULL, nsqd_connection_error_cb,
-        conn);
+                                   rdr->cfg->read_buf_len, rdr->cfg->read_buf_capacity,
+                                   rdr->cfg->write_buf_len, rdr->cfg->write_buf_capacity,
+                                   nsqd_connection_connect_cb, nsqd_connection_close_cb,
+                                   NULL, NULL, nsqd_connection_error_cb,
+                                   conn);
 
     return conn;
 }
@@ -147,7 +147,7 @@ void nsqd_connection_disconnect(nsqdConn *conn)
 }
 
 void nsqd_connection_init_timer(nsqdConn *conn,
-        void (*reconnect_callback)(EV_P_ ev_timer *w, int revents))
+                                void (*reconnect_callback)(EV_P_ ev_timer *w, int revents))
 {
     nsqRdr *rdr = (nsqRdr *)conn->arg;
     conn->reconnect_timer = (ev_timer *)malloc(sizeof(ev_timer));

--- a/nsqd_connection.c
+++ b/nsqd_connection.c
@@ -4,12 +4,12 @@
 #include <string.h>
 
 
-static void nsqd_connection_read_size(nsqBufdSock *buffsock, void *arg);
-static void nsqd_connection_read_data(nsqBufdSock *buffsock, void *arg);
+static void nsqd_connection_read_size(struct BufferedSocket *buffsock, void *arg);
+static void nsqd_connection_read_data(struct BufferedSocket *buffsock, void *arg);
 
-static void nsqd_connection_connect_cb(nsqBufdSock *buffsock, void *arg)
+static void nsqd_connection_connect_cb(struct BufferedSocket *buffsock, void *arg)
 {
-    nsqdConn *conn = (nsqdConn *)arg;
+    struct NSQDConnection *conn = (struct NSQDConnection *)arg;
 
     _DEBUG("%s: %p\n", __FUNCTION__, arg);
 
@@ -24,9 +24,9 @@ static void nsqd_connection_connect_cb(nsqBufdSock *buffsock, void *arg)
     buffered_socket_read_bytes(buffsock, 4, nsqd_connection_read_size, conn);
 }
 
-static void nsqd_connection_read_size(nsqBufdSock *buffsock, void *arg)
+static void nsqd_connection_read_size(struct BufferedSocket *buffsock, void *arg)
 {
-    nsqdConn *conn = (nsqdConn *)arg;
+    struct NSQDConnection *conn = (struct NSQDConnection *)arg;
     uint32_t *msg_size_be;
 
     _DEBUG("%s: %p\n", __FUNCTION__, arg);
@@ -42,10 +42,10 @@ static void nsqd_connection_read_size(nsqBufdSock *buffsock, void *arg)
     buffered_socket_read_bytes(buffsock, conn->current_msg_size, nsqd_connection_read_data, conn);
 }
 
-static void nsqd_connection_read_data(nsqBufdSock *buffsock, void *arg)
+static void nsqd_connection_read_data(struct BufferedSocket *buffsock, void *arg)
 {
-    nsqdConn *conn = (nsqdConn *)arg;
-    nsqMsg *msg;
+    struct NSQDConnection *conn = (struct NSQDConnection *)arg;
+    struct NSQMessage *msg;
 
     conn->current_frame_type = ntohl(*((uint32_t *)buffsock->read_buf->data));
     buffer_drain(buffsock->read_buf, 4);
@@ -76,9 +76,9 @@ static void nsqd_connection_read_data(nsqBufdSock *buffsock, void *arg)
     buffered_socket_read_bytes(buffsock, 4, nsqd_connection_read_size, conn);
 }
 
-static void nsqd_connection_close_cb(nsqBufdSock *buffsock, void *arg)
+static void nsqd_connection_close_cb(struct BufferedSocket *buffsock, void *arg)
 {
-    nsqdConn *conn = (nsqdConn *)arg;
+    struct NSQDConnection *conn = (struct NSQDConnection *)arg;
 
     _DEBUG("%s: %p\n", __FUNCTION__, arg);
 
@@ -87,23 +87,23 @@ static void nsqd_connection_close_cb(nsqBufdSock *buffsock, void *arg)
     }
 }
 
-static void nsqd_connection_error_cb(nsqBufdSock *buffsock, void *arg)
+static void nsqd_connection_error_cb(struct BufferedSocket *buffsock, void *arg)
 {
-    nsqdConn *conn = (nsqdConn *)arg;
+    struct NSQDConnection *conn = (struct NSQDConnection *)arg;
 
     _DEBUG("%s: conn %p\n", __FUNCTION__, conn);
 }
 
-nsqdConn *new_nsqd_connection(struct ev_loop *loop, const char *address, int port,
-                              void (*connect_callback)(nsqdConn *conn, void *arg),
-                              void (*close_callback)(nsqdConn *conn, void *arg),
-                              void (*msg_callback)(nsqdConn *conn, nsqMsg *msg, void *arg),
-                              void *arg)
+struct NSQDConnection *new_nsqd_connection(struct ev_loop *loop, const char *address, int port,
+        void (*connect_callback)(struct NSQDConnection *conn, void *arg),
+        void (*close_callback)(struct NSQDConnection *conn, void *arg),
+        void (*msg_callback)(struct NSQDConnection *conn, struct NSQMessage *msg, void *arg),
+        void *arg)
 {
-    nsqdConn *conn;
-    nsqRdr *rdr = (nsqRdr *)arg;
+    struct NSQDConnection *conn;
+    struct NSQReader *rdr = (struct NSQReader *)arg;
 
-    conn = (nsqdConn *)malloc(sizeof(nsqdConn));
+    conn = (struct NSQDConnection *)malloc(sizeof(struct NSQDConnection));
     conn->address = strdup(address);
     conn->port = port;
     conn->command_buf = new_buffer(rdr->cfg->command_buf_len, rdr->cfg->command_buf_capacity);
@@ -125,7 +125,7 @@ nsqdConn *new_nsqd_connection(struct ev_loop *loop, const char *address, int por
     return conn;
 }
 
-void free_nsqd_connection(nsqdConn *conn)
+void free_nsqd_connection(struct NSQDConnection *conn)
 {
     if (conn) {
         nsqd_connection_stop_timer(conn);
@@ -136,26 +136,26 @@ void free_nsqd_connection(nsqdConn *conn)
     }
 }
 
-int nsqd_connection_connect(nsqdConn *conn)
+int nsqd_connection_connect(struct NSQDConnection *conn)
 {
     return buffered_socket_connect(conn->bs);
 }
 
-void nsqd_connection_disconnect(nsqdConn *conn)
+void nsqd_connection_disconnect(struct NSQDConnection *conn)
 {
     buffered_socket_close(conn->bs);
 }
 
-void nsqd_connection_init_timer(nsqdConn *conn,
+void nsqd_connection_init_timer(struct NSQDConnection *conn,
                                 void (*reconnect_callback)(EV_P_ ev_timer *w, int revents))
 {
-    nsqRdr *rdr = (nsqRdr *)conn->arg;
+    struct NSQReader *rdr = (struct NSQReader *)conn->arg;
     conn->reconnect_timer = (ev_timer *)malloc(sizeof(ev_timer));
     ev_timer_init(conn->reconnect_timer, reconnect_callback, rdr->cfg->lookupd_interval, rdr->cfg->lookupd_interval);
     conn->reconnect_timer->data = conn;
 }
 
-void nsqd_connection_stop_timer(nsqdConn *conn)
+void nsqd_connection_stop_timer(struct NSQDConnection *conn)
 {
     if (conn && conn->reconnect_timer) {
         ev_timer_stop(conn->loop, conn->reconnect_timer);

--- a/nsqlookupd.c
+++ b/nsqlookupd.c
@@ -5,12 +5,12 @@
 #include "utlist.h"
 
 
-void nsq_lookupd_request_cb(httpRequest *req, httpResponse *resp, void *arg)
+void nsq_lookupd_request_cb(struct HttpRequest *req, struct HttpResponse *resp, void *arg)
 {
-    nsqRdr *rdr = (nsqRdr *)arg;
+    struct NSQReader *rdr = (struct NSQReader *)arg;
     nsq_json_t *jsobj, *producers, *producer, *broadcast_address_obj, *tcp_port_obj;
     nsq_json_tokener_t *jstok;
-    nsqdConn *conn;
+    struct NSQDConnection *conn;
     const char *broadcast_address;
     int found, tcp_port;
 
@@ -71,11 +71,11 @@ void nsq_lookupd_request_cb(httpRequest *req, httpResponse *resp, void *arg)
     free_http_request(req);
 }
 
-nsqLE *new_nsqlookupd_endpoint(const char *address, int port)
+struct NSQLookupdEndpoint *new_nsqlookupd_endpoint(const char *address, int port)
 {
-    nsqLE *nsqlookupd_endpoint;
+    struct NSQLookupdEndpoint *nsqlookupd_endpoint;
 
-    nsqlookupd_endpoint = (nsqLE *)malloc(sizeof(nsqLE));
+    nsqlookupd_endpoint = (struct NSQLookupdEndpoint *)malloc(sizeof(struct NSQLookupdEndpoint));
     nsqlookupd_endpoint->address = strdup(address);
     nsqlookupd_endpoint->port = port;
     nsqlookupd_endpoint->next = NULL;
@@ -83,7 +83,7 @@ nsqLE *new_nsqlookupd_endpoint(const char *address, int port)
     return nsqlookupd_endpoint;
 }
 
-void free_nsqlookupd_endpoint(nsqLE *nsqlookupd_endpoint)
+void free_nsqlookupd_endpoint(struct NSQLookupdEndpoint *nsqlookupd_endpoint)
 {
     if (nsqlookupd_endpoint) {
         free(nsqlookupd_endpoint->address);

--- a/nsqlookupd.c
+++ b/nsqlookupd.c
@@ -15,7 +15,7 @@ void nsq_lookupd_request_cb(httpRequest *req, httpResponse *resp, void *arg)
     int found, tcp_port;
 
     _DEBUG("%s: status_code %d, body %.*s\n", __FUNCTION__, resp->status_code,
-        (int)BUFFER_HAS_DATA(resp->data), resp->data->data);
+           (int)BUFFER_HAS_DATA(resp->data), resp->data->data);
 
     if (resp->status_code != 200) {
         free_http_response(resp);
@@ -53,7 +53,7 @@ void nsq_lookupd_request_cb(httpRequest *req, httpResponse *resp, void *arg)
         found = 0;
         LL_FOREACH(rdr->conns, conn) {
             if (strcmp(conn->bs->address, broadcast_address) == 0
-                && conn->bs->port == tcp_port) {
+                    && conn->bs->port == tcp_port) {
                 found = 1;
                 break;
             }

--- a/reader.c
+++ b/reader.c
@@ -43,7 +43,7 @@ static void nsq_reader_msg_cb(nsqdConn *conn, nsqMsg *msg, void *arg)
     _DEBUG("%s: %p %p\n", __FUNCTION__, msg, rdr);
 
     if (rdr->msg_callback) {
-        msg->id[sizeof(msg->id)-1] = '\0';
+        msg->id[sizeof(msg->id) - 1] = '\0';
         rdr->msg_callback(rdr, conn, msg, rdr->ctx);
     }
 }
@@ -94,7 +94,7 @@ static void nsq_reader_lookupd_poll_cb(EV_P_ struct ev_timer *w, int revents)
     LL_FOREACH(rdr->lookupd, nsqlookupd_endpoint) {
         count++;
     }
-    if(count == 0) {
+    if (count == 0) {
         goto end;
     }
     idx = rand() % count;
@@ -105,7 +105,7 @@ static void nsq_reader_lookupd_poll_cb(EV_P_ struct ev_timer *w, int revents)
     LL_FOREACH(rdr->lookupd, nsqlookupd_endpoint) {
         if (i++ == idx) {
             sprintf(buf, "http://%s:%d/lookup?topic=%s", nsqlookupd_endpoint->address,
-                nsqlookupd_endpoint->port, rdr->topic);
+                    nsqlookupd_endpoint->port, rdr->topic);
             req = new_http_request(buf, nsq_lookupd_request_cb, rdr);
             http_client_get((struct HttpClient *)rdr->httpc, req);
             break;
@@ -117,10 +117,10 @@ end:
 }
 
 nsqRdr *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *channel, void *ctx,
-    nsqRdrCfg *cfg,
-    void (*connect_callback)(nsqRdr *rdr, nsqdConn *conn),
-    void (*close_callback)(nsqRdr *rdr, nsqdConn *conn),
-    void (*msg_callback)(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx))
+                       nsqRdrCfg *cfg,
+                       void (*connect_callback)(nsqRdr *rdr, nsqdConn *conn),
+                       void (*close_callback)(nsqRdr *rdr, nsqdConn *conn),
+                       void (*msg_callback)(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx))
 {
     nsqRdr *rdr;
 
@@ -208,7 +208,7 @@ int nsq_reader_connect_to_nsqd(nsqRdr *rdr, const char *address, int port)
     int rc;
 
     conn = new_nsqd_connection(rdr->loop, address, port,
-        nsq_reader_connect_cb, nsq_reader_close_cb, nsq_reader_msg_cb, rdr);
+                               nsq_reader_connect_cb, nsq_reader_close_cb, nsq_reader_msg_cb, rdr);
     rc = nsqd_connection_connect(conn);
     if (rc > 0) {
         LL_APPEND(rdr->conns, conn);

--- a/reader.c
+++ b/reader.c
@@ -15,9 +15,9 @@
 #define DEFAULT_WRITE_BUF_CAPACITY   16 * 1024
 
 
-static void nsq_reader_connect_cb(nsqdConn *conn, void *arg)
+static void nsq_reader_connect_cb(struct NSQDConnection *conn, void *arg)
 {
-    nsqRdr *rdr = (nsqRdr *)arg;
+    struct NSQReader *rdr = (struct NSQReader *)arg;
 
     _DEBUG("%s: %p\n", __FUNCTION__, rdr);
 
@@ -36,9 +36,9 @@ static void nsq_reader_connect_cb(nsqdConn *conn, void *arg)
     buffered_socket_write_buffer(conn->bs, conn->command_buf);
 }
 
-static void nsq_reader_msg_cb(nsqdConn *conn, nsqMsg *msg, void *arg)
+static void nsq_reader_msg_cb(struct NSQDConnection *conn, struct NSQMessage *msg, void *arg)
 {
-    nsqRdr *rdr = (nsqRdr *)arg;
+    struct NSQReader *rdr = (struct NSQReader *)arg;
 
     _DEBUG("%s: %p %p\n", __FUNCTION__, msg, rdr);
 
@@ -48,9 +48,9 @@ static void nsq_reader_msg_cb(nsqdConn *conn, nsqMsg *msg, void *arg)
     }
 }
 
-static void nsq_reader_close_cb(nsqdConn *conn, void *arg)
+static void nsq_reader_close_cb(struct NSQDConnection *conn, void *arg)
 {
-    nsqRdr *rdr = (nsqRdr *)arg;
+    struct NSQReader *rdr = (struct NSQReader *)arg;
 
     _DEBUG("%s: %p\n", __FUNCTION__, rdr);
 
@@ -68,12 +68,12 @@ static void nsq_reader_close_cb(nsqdConn *conn, void *arg)
     }
 }
 
-void nsq_lookupd_request_cb(httpRequest *req, httpResponse *resp, void *arg);
+void nsq_lookupd_request_cb(struct HttpRequest *req, struct HttpResponse *resp, void *arg);
 
 static void nsq_reader_reconnect_cb(EV_P_ struct ev_timer *w, int revents)
 {
-    nsqdConn *conn = (nsqdConn *)w->data;
-    nsqRdr *rdr = (nsqRdr *)conn->arg;
+    struct NSQDConnection *conn = (struct NSQDConnection *)w->data;
+    struct NSQReader *rdr = (struct NSQReader *)conn->arg;
 
     if (rdr->lookupd == NULL) {
         _DEBUG("%s: There is no lookupd, try to reconnect to nsqd directly\n", __FUNCTION__);
@@ -85,9 +85,9 @@ static void nsq_reader_reconnect_cb(EV_P_ struct ev_timer *w, int revents)
 
 static void nsq_reader_lookupd_poll_cb(EV_P_ struct ev_timer *w, int revents)
 {
-    nsqRdr *rdr = (nsqRdr *)w->data;
-    nsqLE *nsqlookupd_endpoint;
-    httpRequest *req;
+    struct NSQReader *rdr = (struct NSQReader *)w->data;
+    struct NSQLookupdEndpoint *nsqlookupd_endpoint;
+    struct HttpRequest *req;
     int i, idx, count = 0;
     char buf[256];
 
@@ -116,16 +116,16 @@ end:
     ev_timer_again(rdr->loop, &rdr->lookupd_poll_timer);
 }
 
-nsqRdr *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *channel, void *ctx,
-                       nsqRdrCfg *cfg,
-                       void (*connect_callback)(nsqRdr *rdr, nsqdConn *conn),
-                       void (*close_callback)(nsqRdr *rdr, nsqdConn *conn),
-                       void (*msg_callback)(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx))
+struct NSQReader *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *channel, void *ctx,
+                                 struct NSQReaderCfg *cfg,
+                                 void (*connect_callback)(struct NSQReader *rdr, struct NSQDConnection *conn),
+                                 void (*close_callback)(struct NSQReader *rdr, struct NSQDConnection *conn),
+                                 void (*msg_callback)(struct NSQReader *rdr, struct NSQDConnection *conn, struct NSQMessage *msg, void *ctx))
 {
-    nsqRdr *rdr;
+    struct NSQReader *rdr;
 
-    rdr = (nsqRdr *)malloc(sizeof(nsqRdr));
-    rdr->cfg = (nsqRdrCfg *)malloc(sizeof(nsqRdrCfg));
+    rdr = (struct NSQReader *)malloc(sizeof(struct NSQReader));
+    rdr->cfg = (struct NSQReaderCfg *)malloc(sizeof(struct NSQReaderCfg));
     if (cfg == NULL) {
         rdr->cfg->lookupd_interval     = DEFAULT_LOOKUPD_INTERVAL;
         rdr->cfg->command_buf_len      = DEFAULT_COMMAND_BUF_LEN;
@@ -159,10 +159,10 @@ nsqRdr *new_nsq_reader(struct ev_loop *loop, const char *topic, const char *chan
     return rdr;
 }
 
-void free_nsq_reader(nsqRdr *rdr)
+void free_nsq_reader(struct NSQReader *rdr)
 {
-    nsqdConn *conn;
-    nsqLE *nsqlookupd_endpoint;
+    struct NSQDConnection *conn;
+    struct NSQLookupdEndpoint *nsqlookupd_endpoint;
 
     if (rdr) {
         // TODO: this should probably trigger disconnections and then keep
@@ -180,10 +180,10 @@ void free_nsq_reader(nsqRdr *rdr)
     }
 }
 
-int nsq_reader_add_nsqlookupd_endpoint(nsqRdr *rdr, const char *address, int port)
+int nsq_reader_add_nsqlookupd_endpoint(struct NSQReader *rdr, const char *address, int port)
 {
-    nsqLE *nsqlookupd_endpoint;
-    nsqdConn *conn;
+    struct NSQLookupdEndpoint *nsqlookupd_endpoint;
+    struct NSQDConnection *conn;
 
     if (rdr->lookupd == NULL) {
         // Stop reconnect timers, use lookupd timer instead
@@ -202,9 +202,9 @@ int nsq_reader_add_nsqlookupd_endpoint(nsqRdr *rdr, const char *address, int por
     return 1;
 }
 
-int nsq_reader_connect_to_nsqd(nsqRdr *rdr, const char *address, int port)
+int nsq_reader_connect_to_nsqd(struct NSQReader *rdr, const char *address, int port)
 {
-    nsqdConn *conn;
+    struct NSQDConnection *conn;
     int rc;
 
     conn = new_nsqd_connection(rdr->loop, address, port,

--- a/test.c
+++ b/test.c
@@ -1,6 +1,6 @@
 #include "nsq.h"
 
-static void message_handler(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx)
+static void message_handler(struct NSQReader *rdr, struct NSQDConnection *conn, struct NSQMessage *msg, void *ctx)
 {
     _DEBUG("%s: %lld, %d, %s, %lu, %.*s\n", __FUNCTION__, msg->timestamp, msg->attempts, msg->id,
            msg->body_length, (int)msg->body_length, msg->body);
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
         printf("not enough args from command line\n");
         return 1;
     }
-    nsqRdr *rdr;
+    struct NSQReader *rdr;
     struct ev_loop *loop;
     void *ctx = NULL; //(void *)(new TestNsqMsgContext());
 

--- a/test.c
+++ b/test.c
@@ -3,16 +3,16 @@
 static void message_handler(nsqRdr *rdr, nsqdConn *conn, nsqMsg *msg, void *ctx)
 {
     _DEBUG("%s: %lld, %d, %s, %lu, %.*s\n", __FUNCTION__, msg->timestamp, msg->attempts, msg->id,
-        msg->body_length, (int)msg->body_length, msg->body);
+           msg->body_length, (int)msg->body_length, msg->body);
     int ret = 0;
     //TestNsqMsgContext * test_ctx = (TestNsqMsgContext *)ctx;
     //int ret= ctx->process(msg->body, msg->body_length);
 
     buffer_reset(conn->command_buf);
 
-    if(ret < 0){
+    if (ret < 0) {
         nsq_requeue(conn->command_buf, msg->id, 100);
-    }else{
+    } else {
         nsq_finish(conn->command_buf, msg->id);
     }
     buffered_socket_write_buffer(conn->bs, conn->command_buf);

--- a/test_evbuffsock.c
+++ b/test_evbuffsock.c
@@ -5,16 +5,16 @@
 int main(int argc, char **argv)
 {
     struct Buffer *buf;
-    
+
     buf = new_buffer(16, 64);
     buffer_add(buf, "asdf", 4);
     buffer_add(buf, "1234567890", 10);
     buffer_add(buf, "ghjk", 4);
-    
+
     buffer_drain(buf, 8);
     buffer_add(buf, "1234567890", 10);
     buffer_add(buf, "!@#$%^", 6);
-    
+
     assert(buf->length == 32);
     assert(strncmp("567890ghjk1234567890!@#$%^", buf->data, buf->offset) == 0);
     printf("OK\n");


### PR DESCRIPTION
```
astyle --style=1tbs --lineend=linux --convert-tabs --preserve-date --pad-header --indent-switches --align-pointer=name --align-reference=name --pad-oper
```

Also removed `typedef`s, I don't like 'em 😀 